### PR TITLE
Remove React.FC from template

### DIFF
--- a/template/src/app/App.tsx
+++ b/template/src/app/App.tsx
@@ -1,5 +1,5 @@
 import 'react-native-gesture-handler';
-import React, {FC} from 'react';
+import React from 'react';
 import {NavigationContainer} from '@react-navigation/native';
 import {createMaterialTopTabNavigator} from '@react-navigation/material-top-tabs';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
@@ -8,7 +8,7 @@ import {SafeAreaView} from 'react-native';
 
 const Tab = createMaterialTopTabNavigator();
 
-const App: FC = () => {
+const App = (): JSX.Element => {
   return (
     <SafeAreaProvider>
       <SafeAreaView style={{flex: 1}}>

--- a/template/src/app/components/DebugInstructions/DebugInstructions.tsx
+++ b/template/src/app/components/DebugInstructions/DebugInstructions.tsx
@@ -1,7 +1,7 @@
-import React, {FC} from 'react';
+import React from 'react';
 import {StyleSheet, Text, Platform} from 'react-native';
 
-export const DebugInstructions: FC = Platform.select({
+export const DebugInstructions = Platform.select({
   web: () => (
     <Text>
       Press <Text style={styles.highlight}>F12</Text> in the browser to open{' '}

--- a/template/src/app/components/Header/Header.tsx
+++ b/template/src/app/components/Header/Header.tsx
@@ -1,7 +1,7 @@
-import React, {FC} from 'react';
+import React from 'react';
 import {ImageBackground, StyleSheet, Text} from 'react-native';
 
-export const Header: FC = () => {
+export const Header = (): JSX.Element => {
   return (
     <ImageBackground
       accessibilityRole='image'

--- a/template/src/app/components/LearnMoreLinks/LearnMoreLinks.tsx
+++ b/template/src/app/components/LearnMoreLinks/LearnMoreLinks.tsx
@@ -1,8 +1,8 @@
-import React, {FC, Fragment} from 'react';
+import React, {Fragment} from 'react';
 import {StyleSheet, Text, TouchableOpacity, View, Linking} from 'react-native';
 import {links} from 'static/constants';
 
-export const LearnMoreLinks: FC = () => {
+export const LearnMoreLinks = (): JSX.Element => {
   return (
     <View style={styles.container}>
       {links.map(({id, title, link, description}) => (

--- a/template/src/app/components/Section/Section.tsx
+++ b/template/src/app/components/Section/Section.tsx
@@ -1,4 +1,4 @@
-import React, {FC, ReactNode} from 'react';
+import React, {ReactNode} from 'react';
 import {StyleSheet, Text, View} from 'react-native';
 
 interface ISection {
@@ -6,7 +6,7 @@ interface ISection {
   title: string;
 }
 
-export const Section: FC<ISection> = ({children, title}) => {
+export const Section = ({children, title}: ISection): JSX.Element => {
   return (
     <View style={styles.sectionContainer}>
       <Text style={styles.sectionTitle}>{title}</Text>

--- a/template/src/app/components/package.json
+++ b/template/src/app/components/package.json
@@ -1,5 +1,4 @@
 {
-  "name": "components",
   "private": true,
   "main": "components.tsx"
 }

--- a/template/src/app/pages/Details/Details.tsx
+++ b/template/src/app/pages/Details/Details.tsx
@@ -1,8 +1,8 @@
-import React, {FC} from 'react';
+import React from 'react';
 import {Text, SafeAreaView, StyleSheet} from 'react-native';
 import Icon from 'react-native-vector-icons/FontAwesome';
 
-export const Details: FC = () => (
+export const Details = (): JSX.Element => (
   <SafeAreaView style={styles.background}>
     <Icon name='rocket' size={30} color='#900' />
     <Text>If you see a rocket, everything is working!</Text>

--- a/template/src/app/pages/Home/Home.tsx
+++ b/template/src/app/pages/Home/Home.tsx
@@ -1,8 +1,8 @@
-import React, {FC} from 'react';
+import React from 'react';
 import {SafeAreaView, ScrollView, StatusBar, StyleSheet, Text, useColorScheme, View} from 'react-native';
 import {Section, DebugInstructions, LearnMoreLinks, Header} from 'app/components';
 
-export const Home: FC = () => {
+export const Home = (): JSX.Element => {
   const isDarkMode = useColorScheme() === 'dark';
 
   return (

--- a/template/src/app/pages/package.json
+++ b/template/src/app/pages/package.json
@@ -1,5 +1,4 @@
 {
-  "name": "pages",
   "private": true,
   "main": "pages.tsx"
 }


### PR DESCRIPTION
Removes any occurrence of React.FC.

Also removes "name" property from components' and pages'  package.json. You can use this to use absolute modules in React Native, but they wont work for the web. Having **baseUrl: "src"** in tsconfig will work for the web, but you will have to add a package.json with a name for each absolute module in src to make it work for React Native aswell.

Fixes #13 