### PR TITLE
Release v1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@
 
 ## ⭐ Features
 - [React Native Web](https://necolas.github.io/react-native-web/)
-- [React Navigation](https://reactnavigation.org/) 
-- [React Native Elements](https://reactnativeelements.com/)
+- [React Navigation](https://reactnavigation.org/)
 - [React Native Vector Icons](https://github.com/oblador/react-native-vector-icons)
 - [TypeScript](https://www.typescriptlang.org/)
 - Other

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plaut-ro/luna",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Luna is a React Native boilerplate with minimal configuration so your app can run on Android, IOS and Web concurrently.",
   "repository": "git@github.com:plaut-ro/luna.git",
   "publishConfig": {

--- a/template/config-overrides.js
+++ b/template/config-overrides.js
@@ -20,9 +20,6 @@ module.exports = override(
   }),
   babelInclude([
     path.resolve(__dirname, 'src'),
-    path.resolve(__dirname, 'node_modules/react-native-elements'),
-    path.resolve(__dirname, 'node_modules/react-native-vector-icons'),
-    path.resolve(__dirname, 'node_modules/react-native-dynamic-vector-icons'),
-    path.resolve(__dirname, 'node_modules/react-native-ratings')
+    path.resolve(__dirname, 'node_modules/react-native-vector-icons')
   ])
 );

--- a/template/package.json
+++ b/template/package.json
@@ -26,7 +26,6 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-native": "0.66.1",
-    "react-native-elements": "^3.4.2",
     "react-native-gesture-handler": "^1.10.3",
     "react-native-pager-view": "^5.4.7",
     "react-native-safe-area-context": "^3.3.2",
@@ -42,6 +41,7 @@
     "@types/jest": "^27.0.1",
     "@types/react": "^17.0.19",
     "@types/react-native": "^0.66.1",
+    "@types/react-native-vector-icons": "^6.4.9",
     "@types/react-test-renderer": "^17.0.1",
     "@typescript-eslint/eslint-plugin": "^4.31.0",
     "@typescript-eslint/parser": "^4.31.0",
@@ -75,7 +75,7 @@
     "transformIgnorePatterns": [
       "node_modules/(?!react-native|@react-native|react-native-vector-icons)"
     ]
-    },
+  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/template/src/app/App.tsx
+++ b/template/src/app/App.tsx
@@ -1,5 +1,5 @@
 import 'react-native-gesture-handler';
-import React, {FC} from 'react';
+import React from 'react';
 import {NavigationContainer} from '@react-navigation/native';
 import {createMaterialTopTabNavigator} from '@react-navigation/material-top-tabs';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
@@ -8,7 +8,7 @@ import {SafeAreaView} from 'react-native';
 
 const Tab = createMaterialTopTabNavigator();
 
-const App: FC = () => {
+const App = (): JSX.Element => {
   return (
     <SafeAreaProvider>
       <SafeAreaView style={{flex: 1}}>

--- a/template/src/app/components/DebugInstructions/DebugInstructions.tsx
+++ b/template/src/app/components/DebugInstructions/DebugInstructions.tsx
@@ -1,7 +1,7 @@
-import React, {FC} from 'react';
+import React from 'react';
 import {StyleSheet, Text, Platform} from 'react-native';
 
-export const DebugInstructions: FC = Platform.select({
+export const DebugInstructions = Platform.select({
   web: () => (
     <Text>
       Press <Text style={styles.highlight}>F12</Text> in the browser to open{' '}

--- a/template/src/app/components/Header/Header.tsx
+++ b/template/src/app/components/Header/Header.tsx
@@ -1,7 +1,7 @@
-import React, {FC} from 'react';
+import React from 'react';
 import {ImageBackground, StyleSheet, Text} from 'react-native';
 
-export const Header: FC = () => {
+export const Header = (): JSX.Element => {
   return (
     <ImageBackground
       accessibilityRole='image'

--- a/template/src/app/components/LearnMoreLinks/LearnMoreLinks.tsx
+++ b/template/src/app/components/LearnMoreLinks/LearnMoreLinks.tsx
@@ -1,8 +1,8 @@
-import React, {FC, Fragment} from 'react';
+import React, {Fragment} from 'react';
 import {StyleSheet, Text, TouchableOpacity, View, Linking} from 'react-native';
 import {links} from 'static/constants';
 
-export const LearnMoreLinks: FC = () => {
+export const LearnMoreLinks = (): JSX.Element => {
   return (
     <View style={styles.container}>
       {links.map(({id, title, link, description}) => (

--- a/template/src/app/components/Section/Section.tsx
+++ b/template/src/app/components/Section/Section.tsx
@@ -1,4 +1,4 @@
-import React, {FC, ReactNode} from 'react';
+import React, {ReactNode} from 'react';
 import {StyleSheet, Text, View} from 'react-native';
 
 interface ISection {
@@ -6,7 +6,7 @@ interface ISection {
   title: string;
 }
 
-export const Section: FC<ISection> = ({children, title}) => {
+export const Section = ({children, title}: ISection): JSX.Element => {
   return (
     <View style={styles.sectionContainer}>
       <Text style={styles.sectionTitle}>{title}</Text>

--- a/template/src/app/components/package.json
+++ b/template/src/app/components/package.json
@@ -1,5 +1,4 @@
 {
-  "name": "components",
   "private": true,
   "main": "components.tsx"
 }

--- a/template/src/app/pages/Details/Details.tsx
+++ b/template/src/app/pages/Details/Details.tsx
@@ -1,8 +1,8 @@
-import React, {FC} from 'react';
+import React from 'react';
 import {Text, SafeAreaView, StyleSheet} from 'react-native';
 import Icon from 'react-native-vector-icons/FontAwesome';
 
-export const Details: FC = () => (
+export const Details = (): JSX.Element => (
   <SafeAreaView style={styles.background}>
     <Icon name='rocket' size={30} color='#900' />
     <Text>If you see a rocket, everything is working!</Text>

--- a/template/src/app/pages/Home/Home.tsx
+++ b/template/src/app/pages/Home/Home.tsx
@@ -1,8 +1,8 @@
-import React, {FC} from 'react';
+import React from 'react';
 import {SafeAreaView, ScrollView, StatusBar, StyleSheet, Text, useColorScheme, View} from 'react-native';
 import {Section, DebugInstructions, LearnMoreLinks, Header} from 'app/components';
 
-export const Home: FC = () => {
+export const Home = (): JSX.Element => {
   const isDarkMode = useColorScheme() === 'dark';
 
   return (

--- a/template/src/app/pages/package.json
+++ b/template/src/app/pages/package.json
@@ -1,5 +1,4 @@
 {
-  "name": "pages",
   "private": true,
   "main": "pages.tsx"
 }


### PR DESCRIPTION
- removes React.FC from the template because it has a few downsides. More information here: https://github.com/facebook/create-react-app/pull/8177
- removes react-native-elements because it's not needed. The user should be able to choose what he'd like to use. react-native-vector-icons and react-navigation are staying because they're the the recommended choice to use React Native for web.