### PR TITLE
New JSX transform

### DIFF
--- a/template/babel.config.js
+++ b/template/babel.config.js
@@ -1,3 +1,11 @@
 module.exports = {
-  presets: ['module:metro-react-native-babel-preset']
+  presets: [['module:metro-react-native-babel-preset', {useTransformReactJSXExperimental: true}]],
+  plugins: [
+    [
+      '@babel/plugin-transform-react-jsx',
+      {
+        runtime: 'automatic'
+      }
+    ]
+  ]
 };

--- a/template/craco.config.js
+++ b/template/craco.config.js
@@ -9,6 +9,9 @@ const {
   POSTCSS_MODES
 } = require('@craco/craco');
 
+const path = require('path');
+const appDirectory = path.resolve(__dirname, '../');
+
 module.exports = {
   // reactScriptsVersion: 'react-scripts' /* (default value) */,
   // style: {
@@ -71,21 +74,34 @@ module.exports = {
   // },
 
   babel: {
-    presets: [
-      [
-        '@babel/preset-react',
-        {
-          runtime: 'automatic'
-        }
-      ]
-    ],
-    plugins: ['babel-plugin-react-native-web', '@babel/plugin-proposal-class-properties'],
+    presets: [],
+    plugins: [],
     loaderOptions: {
       /* Any babel-loader configuration options: https://github.com/babel/babel-loader. */
-    },
-    loaderOptions: (babelLoaderOptions, {env, paths}) => {
-      return babelLoaderOptions;
+      //   cacheDirectory: true,
+
+      presets: [
+        // The 'metro-react-native-babel-preset' preset is recommended to match React Native's packager
+        ['module:metro-react-native-babel-preset', {useTransformReactJSXExperimental: true}],
+        '@babel/preset-env',
+        '@babel/preset-react'
+      ],
+      // Re-write paths to import only the modules needed by the app
+      plugins: [
+        'react-native-web',
+        [
+          // Enable new JSX Transform from React
+          '@babel/plugin-transform-react-jsx',
+          {
+            runtime: 'automatic'
+          }
+        ]
+      ]
     }
+    // loaderOptions: (babelLoaderOptions, {env, paths}) => {
+    //
+    //   return babelLoaderOptions;
+    // }
   },
   // typescript: {
   //   enableTypeChecking: true /* (default value)  */

--- a/template/craco.config.js
+++ b/template/craco.config.js
@@ -9,9 +9,6 @@ const {
   POSTCSS_MODES
 } = require('@craco/craco');
 
-const path = require('path');
-const appDirectory = path.resolve(__dirname, '../');
-
 module.exports = {
   // reactScriptsVersion: 'react-scripts' /* (default value) */,
   // style: {
@@ -80,6 +77,7 @@ module.exports = {
     ],
 
     plugins: [
+      // https://necolas.github.io/react-native-web/docs/setup/#package-optimization
       'react-native-web',
       [
         // Enable new JSX Transform from React

--- a/template/craco.config.js
+++ b/template/craco.config.js
@@ -71,17 +71,15 @@ module.exports = {
   // },
 
   babel: {
-    presets: ['@babel/preset-react'],
-    plugins: [
-      'babel-plugin-react-native-web',
-      '@babel/plugin-proposal-class-properties',
+    presets: [
       [
-        '@babel/plugin-transform-react-jsx',
+        '@babel/preset-react',
         {
           runtime: 'automatic'
         }
       ]
     ],
+    plugins: ['babel-plugin-react-native-web', '@babel/plugin-proposal-class-properties'],
     loaderOptions: {
       /* Any babel-loader configuration options: https://github.com/babel/babel-loader. */
     },

--- a/template/craco.config.js
+++ b/template/craco.config.js
@@ -82,11 +82,9 @@ module.exports = {
 
       presets: [
         // The 'metro-react-native-babel-preset' preset is recommended to match React Native's packager
-        ['module:metro-react-native-babel-preset', {useTransformReactJSXExperimental: true}],
-        '@babel/preset-env',
-        '@babel/preset-react'
+        ['module:metro-react-native-babel-preset', {useTransformReactJSXExperimental: true}]
       ],
-      // Re-write paths to import only the modules needed by the app
+
       plugins: [
         'react-native-web',
         [

--- a/template/craco.config.js
+++ b/template/craco.config.js
@@ -74,30 +74,25 @@ module.exports = {
   // },
 
   babel: {
-    presets: [],
-    plugins: [],
+    presets: [
+      // The 'metro-react-native-babel-preset' preset is recommended to match React Native's packager
+      ['module:metro-react-native-babel-preset', {useTransformReactJSXExperimental: true}]
+    ],
+
+    plugins: [
+      'react-native-web',
+      [
+        // Enable new JSX Transform from React
+        '@babel/plugin-transform-react-jsx',
+        {
+          runtime: 'automatic'
+        }
+      ]
+    ],
     loaderOptions: {
       /* Any babel-loader configuration options: https://github.com/babel/babel-loader. */
-      //   cacheDirectory: true,
-
-      presets: [
-        // The 'metro-react-native-babel-preset' preset is recommended to match React Native's packager
-        ['module:metro-react-native-babel-preset', {useTransformReactJSXExperimental: true}]
-      ],
-
-      plugins: [
-        'react-native-web',
-        [
-          // Enable new JSX Transform from React
-          '@babel/plugin-transform-react-jsx',
-          {
-            runtime: 'automatic'
-          }
-        ]
-      ]
     }
     // loaderOptions: (babelLoaderOptions, {env, paths}) => {
-    //
     //   return babelLoaderOptions;
     // }
   },

--- a/template/package.json
+++ b/template/package.json
@@ -23,6 +23,7 @@
     "@react-navigation/material-top-tabs": "^6.0.6",
     "@react-navigation/native": "^6.0.6",
     "@react-navigation/stack": "^6.0.11",
+    "babel-plugin-react-native-web": "^0.17.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-native": "^0.66.2",

--- a/template/package.json
+++ b/template/package.json
@@ -46,7 +46,6 @@
     "@types/react-test-renderer": "^17.0.1",
     "@typescript-eslint/eslint-plugin": "^4.31.0",
     "@typescript-eslint/parser": "^4.31.0",
-    "babel-plugin-react-native-web": "^0.17.1",
     "eslint": "^7.32.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.26.1",

--- a/template/src/app/App.tsx
+++ b/template/src/app/App.tsx
@@ -1,5 +1,4 @@
 import 'react-native-gesture-handler';
-import React from 'react';
 import {NavigationContainer} from '@react-navigation/native';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
 import {StatusBar} from 'react-native';

--- a/template/src/app/components/DebugInstructions/DebugInstructions.tsx
+++ b/template/src/app/components/DebugInstructions/DebugInstructions.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {StyleSheet, Text, Platform} from 'react-native';
 
 export const DebugInstructions = Platform.select({

--- a/template/src/app/components/Header/Header.tsx
+++ b/template/src/app/components/Header/Header.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {ImageBackground, StyleSheet, Text} from 'react-native';
 
 export const Header = (): JSX.Element => {

--- a/template/src/app/components/LearnMoreLinks/LearnMoreLinks.tsx
+++ b/template/src/app/components/LearnMoreLinks/LearnMoreLinks.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment} from 'react';
+import {Fragment} from 'react';
 import {StyleSheet, Text, TouchableOpacity, View, Linking, Platform} from 'react-native';
 import {links} from 'static/constants';
 import {useColors} from 'app/hooks/useColors';

--- a/template/src/app/components/Section/Section.tsx
+++ b/template/src/app/components/Section/Section.tsx
@@ -1,4 +1,4 @@
-import React, {ReactNode} from 'react';
+import {ReactNode} from 'react';
 import {StyleSheet, Text, View} from 'react-native';
 
 interface ISection {

--- a/template/src/app/navigation/TopTabNavigator.tsx
+++ b/template/src/app/navigation/TopTabNavigator.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {createMaterialTopTabNavigator} from '@react-navigation/material-top-tabs';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useColors} from '../hooks/useColors';

--- a/template/src/app/navigation/pages/Details/Details.tsx
+++ b/template/src/app/navigation/pages/Details/Details.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {Text, StyleSheet, View, Platform} from 'react-native';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import {useColors} from 'app/hooks/useColors';

--- a/template/src/app/navigation/pages/Home/Home.tsx
+++ b/template/src/app/navigation/pages/Home/Home.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {Platform, ScrollView, StyleSheet, Text, View} from 'react-native';
 import {Section, DebugInstructions, LearnMoreLinks, Header} from 'app/components';
 import {SafeAreaView} from 'react-native-safe-area-context';


### PR DESCRIPTION
- Enables the [new JSX Transform](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) from React.
- Removes all `React` imports.
- Improves react-native-web setup