### PR TITLE
fix(paths): use directory-relative paths

### DIFF
--- a/template/src/app/App.tsx
+++ b/template/src/app/App.tsx
@@ -2,8 +2,8 @@ import 'react-native-gesture-handler';
 import {NavigationContainer} from '@react-navigation/native';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
 import {StatusBar} from 'react-native';
-import {useColors} from 'app/hooks/useColors';
-import {TopTabNavigator} from 'app/navigation/TopTabNavigator';
+import {useColors} from './hooks/useColors';
+import {TopTabNavigator} from './navigation/TopTabNavigator';
 
 const App = (): JSX.Element => {
   const {isDarkMode, backgroundColor} = useColors();

--- a/template/src/app/components/LearnMoreLinks/LearnMoreLinks.tsx
+++ b/template/src/app/components/LearnMoreLinks/LearnMoreLinks.tsx
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 import {StyleSheet, TouchableOpacity, View, Linking} from 'react-native';
 import {links} from 'static/constants';
-import {useColors} from 'app/hooks/useColors';
+import {useColors} from '../..//hooks/useColors';
 import {StyledText} from '../StyledText';
 
 export const LearnMoreLinks = (): JSX.Element => {

--- a/template/src/app/navigation/pages/Details/Details.tsx
+++ b/template/src/app/navigation/pages/Details/Details.tsx
@@ -1,7 +1,7 @@
 import {StyleSheet, View} from 'react-native';
 import Icon from 'react-native-vector-icons/FontAwesome';
-import {useColors} from 'app/hooks/useColors';
-import {StyledText} from 'app/components';
+import {useColors} from '../../../hooks/useColors';
+import {StyledText} from '../../../components';
 
 export const Details = (): JSX.Element => {
   const {backgroundColor, color} = useColors();

--- a/template/src/app/navigation/pages/Home/Home.tsx
+++ b/template/src/app/navigation/pages/Home/Home.tsx
@@ -1,7 +1,7 @@
 import {ScrollView, StyleSheet, Text, View} from 'react-native';
-import {Section, DebugInstructions, LearnMoreLinks, Header} from 'app/components';
+import {Section, DebugInstructions, LearnMoreLinks, Header} from '../../../components';
 import {SafeAreaView} from 'react-native-safe-area-context';
-import {useColors} from 'app/hooks/useColors';
+import {useColors} from '../../../hooks/useColors';
 
 export const Home = (): JSX.Element => {
   const {backgroundColor} = useColors();


### PR DESCRIPTION
If this template is used to init a project, then the app directory itself
is moved, the components inside app lose their ability to resolve and lint:types
no longer works

If I use directory-relative paths, everything appears fine

Related: https://github.com/invertase/react-native-firebase-authentication-example/pull/3

This was the only change I needed in this template when layering that one on top