### PR TITLE
docs(README): no longer contains elements, link to icons readme

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -7,8 +7,7 @@
 - [React Native Web](https://necolas.github.io/react-native-web/)
 - [TypeScript](https://www.typescriptlang.org/)
 - [React Navigation](https://reactnavigation.org/)
-- [React Native Elements](https://reactnativeelements.com/)
-- [React Native Vector Icons](https://github.com/oblador/react-native-vector-icons)
+- [React Native Vector Icons](https://github.com/oblador/react-native-vector-icons#readme)
 
 ## Running the app
 


### PR DESCRIPTION

tiny tweaks to readme - I'm prepping the react-native-firebase auth template for launch so I am grooming the README over there, noticed these and thought to post them back