### PR TITLE
feat(web): add web-compatible linking and titling in react-navigation

### DIFF
--- a/template/android/gradle.properties
+++ b/template/android/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/template/src/App.tsx
+++ b/template/src/App.tsx
@@ -10,7 +10,14 @@
 
 import appJson from './app.json';
 import React from 'react';
-import {ScrollView, StyleSheet, Text, useColorScheme, View} from 'react-native';
+import {
+  Button,
+  ScrollView,
+  StyleSheet,
+  Text,
+  useColorScheme,
+  View,
+} from 'react-native';
 import {
   Colors,
   DebugInstructions,
@@ -23,6 +30,7 @@ import {
   SafeAreaProvider,
   useSafeAreaInsets,
 } from 'react-native-safe-area-context';
+import {useLinkTo} from '@react-navigation/native';
 import {createMaterialTopTabNavigator} from '@react-navigation/material-top-tabs';
 import Icon from 'react-native-vector-icons/FontAwesome';
 
@@ -105,6 +113,9 @@ const TopTabNavigator = () => {
   // Used for status bar layout in react-navigation
   const insets = useSafeAreaInsets();
 
+  // Allows us to use web-compatible navigation
+  const linkTo = useLinkTo();
+
   // Dark mode theming items
   const isDarkMode = useColorScheme() === 'dark';
   const accentColor = isDarkMode ? Colors.ligher : Colors.darker;
@@ -125,6 +136,13 @@ const TopTabNavigator = () => {
       </Text>
     </View>
   );
+  const LinkingExample = () => {
+    return (
+      <View style={[backgroundStyle, styles.detailsContainer]}>
+        <Button title="Link to Details" onPress={() => linkTo('/details')} />
+      </View>
+    );
+  };
 
   const screenOptions = {
     tabBarStyle: {
@@ -139,6 +157,7 @@ const TopTabNavigator = () => {
     <Tab.Navigator initialRouteName="Home" screenOptions={screenOptions}>
       <Tab.Screen component={App} key={'Home'} name={'Home'} />
       <Tab.Screen component={DetailsTab} key={'Details'} name={'Details'} />
+      <Tab.Screen component={LinkingExample} key={'Linking'} name={'Linking'} />
     </Tab.Navigator>
   );
 };
@@ -147,6 +166,16 @@ const TabbedApp = () => {
   return (
     <SafeAreaProvider>
       <NavigationContainer
+        linking={{
+          prefixes: ['plaut-ro.github.io/luna', 'localhost'],
+          config: {
+            screens: {
+              Details: 'details',
+              Linking: 'linking',
+              Home: '*', // Fall back to if no routes match
+            },
+          },
+        }}
         documentTitle={{
           formatter: (options, route) =>
             `${appJson.displayName} - ${options?.title ?? route?.name}`,

--- a/template/src/App.tsx
+++ b/template/src/App.tsx
@@ -8,6 +8,7 @@
  * @format
  */
 
+import appJson from './app.json';
 import React from 'react';
 import {ScrollView, StyleSheet, Text, useColorScheme, View} from 'react-native';
 import {
@@ -145,7 +146,11 @@ const TopTabNavigator = () => {
 const TabbedApp = () => {
   return (
     <SafeAreaProvider>
-      <NavigationContainer>
+      <NavigationContainer
+        documentTitle={{
+          formatter: (options, route) =>
+            `${appJson.displayName} - ${options?.title ?? route?.name}`,
+        }}>
         <TopTabNavigator />
       </NavigationContainer>
     </SafeAreaProvider>


### PR DESCRIPTION
I am new to the web stuff and forgot that managing the title URL in the browser bar is really important.

Not only does it pay to have the web title bar look nice (for bookmarking) but URL management is important for aesthetics, again for bookmarking (deep link recognition and page routing...) but most importantly: so the back button doesn't destroy your app's navigation state

So this adds a semi-fancy page title function as an example, and adds a third tab + config that shows how the whole thing works using the web-compatible version of react-navigation linking

As a PR it's kind of "meh" at the same time that I immediately noticed I needed it 2 layers up in my work projects, curious what you think here? If it looks good I'll expand it for the auth template