### PR TITLE
feat(pages): auto-deploy to github-pages on merge to master

### DIFF
--- a/.github/workflows/pages-build.yml
+++ b/.github/workflows/pages-build.yml
@@ -1,0 +1,28 @@
+name: Github Pages Deployment
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - name: Install Packages
+        run: cd template && yarn
+      - name: Build page
+        run: |
+          export REPO_OWNER=`echo $GITHUB_REPOSITORY | cut -d'/' -f1`
+          export REPO=`echo $GITHUB_REPOSITORY | cut -d'/' -f2`
+          export PUBLIC_URL=https://${REPO_OWNER}.github.io/${REPO}
+          cd template && yarn build-web
+        shell: bash
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./template/build


### PR DESCRIPTION

Fixes #37 

First publish will fail as the gh-pages branch doesn't exist and Pages (in repo settings) isn't configured to use it

This should create the gh-pages branch first time it runs
Then configure Pages in repo settings to use the gh-pages branch
Then manually run the workflow again in the Actions tab on the repo (it responds to "workflow_dispatch" event, so you can run it manually)

It works!
https://github.com/invertase/react-native-firebase-authentication-example/runs/4423730053?check_suite_focus=true
https://invertase.github.io/react-native-firebase-authentication-example/