### PR TITLE
perf: use initialWindowMetrics on SafeAreProvider

### DIFF
--- a/template/src/App.tsx
+++ b/template/src/App.tsx
@@ -27,6 +27,7 @@ import {
   // @ts-ignore -- these are not well typed, but are only example screens
 } from '../node_modules/react-native/Libraries/NewAppScreen';
 import {
+  initialWindowMetrics,
   SafeAreaProvider,
   useSafeAreaInsets,
 } from 'react-native-safe-area-context';
@@ -164,7 +165,7 @@ const TopTabNavigator = () => {
 
 const TabbedApp = () => {
   return (
-    <SafeAreaProvider>
+    <SafeAreaProvider initialMetrics={initialWindowMetrics}>
       <NavigationContainer
         linking={{
           prefixes: ['plaut-ro.github.io/luna', 'localhost'],


### PR DESCRIPTION
https://github.com/th3rdwave/react-native-safe-area-context#optimization

appears to work in testing, can't see why not to use it per docs

not the most important thing in the world but when you're reading docs, and you see things, best just to do them instead of add to a list...