### PR TITLE
style(lint): remove eslint quotes rules so prettier wins

### DIFF
--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -31,7 +31,6 @@ module.exports = {
   rules: {
     '@typescript-eslint/no-var-requires': 'off',
     'linebreak-style': ['error', 'unix'], // https://adaptivepatchwork.com/2012/03/01/mind-the-end-of-your-line/
-    quotes: ['error', 'single'],
     semi: ['error', 'always'],
     'prettier/prettier': 'error',
     'react/display-name': 'off',


### PR DESCRIPTION
prettier allows double-quotes on strings if you have a single-quote *in*
the string that you would need to escape. It's subtle, but prettier

eslint was trying to overrule that, so there was a linting battle

this lets prettier win

may not be generally applicable (it only happened to me when doing translations on authentication errors - lots of strings) but it simplifies the config so it seems reasonable to have it in the base layer of the templates