### PR TITLE
fix(web): if no page title or route title, don't emit hyphen

### DIFF
--- a/template/src/App.tsx
+++ b/template/src/App.tsx
@@ -178,7 +178,11 @@ const TabbedApp = () => {
         }}
         documentTitle={{
           formatter: (options, route) =>
-            `${appJson.displayName} - ${options?.title ?? route?.name}`,
+            `${appJson.displayName}${
+              options?.title || route?.name
+                ? ' - ' + options?.title ?? route?.name
+                : ' '
+            }`,
         }}>
         <TopTabNavigator />
       </NavigationContainer>


### PR DESCRIPTION
saw this as a corner case of a routing issue I was having.
It may not happen for most people that have their Linking set up
correctly, but if for some reason you have a null title and no
route name, the formatter shouldn't emit a hypen in web title