### PR TITLE
fix(lint): silence warnings during web production build

### DIFF
--- a/template/babel.config.js
+++ b/template/babel.config.js
@@ -7,6 +7,10 @@ module.exports = {
       {
         runtime: 'automatic'
       }
-    ]
-  ]
+    ],
+    ['@babel/plugin-proposal-decorators', {legacy: true}],
+    ['@babel/plugin-proposal-class-properties', {loose: true}],
+    ["@babel/plugin-proposal-private-methods", { "loose": true }],
+    ["@babel/plugin-proposal-private-property-in-object", { "loose": true }]
+]
 };

--- a/template/craco.config.js
+++ b/template/craco.config.js
@@ -85,7 +85,11 @@ module.exports = {
         {
           runtime: 'automatic'
         }
-      ]
+      ],
+      ['@babel/plugin-proposal-decorators', {legacy: true}],
+      ['@babel/plugin-proposal-class-properties', {loose: true}],
+      ["@babel/plugin-proposal-private-methods", { "loose": true }],
+      ["@babel/plugin-proposal-private-property-in-object", { "loose": true }]
     ],
     loaderOptions: {
       /* Any babel-loader configuration options: https://github.com/babel/babel-loader. */


### PR DESCRIPTION
craco / webpack was complaining about some of our language
proposal choices not lining up correctly, this silences the warnings